### PR TITLE
Switched from string to datetime in sighting post endpoint

### DIFF
--- a/src/main/java/com/example/trainspottingjava/sighting/model/Sighting.java
+++ b/src/main/java/com/example/trainspottingjava/sighting/model/Sighting.java
@@ -2,8 +2,13 @@ package com.example.trainspottingjava.sighting.model;
 
 import com.example.trainspottingjava.station.model.Station;
 import com.example.trainspottingjava.train.model.Train;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.google.cloud.firestore.annotation.DocumentId;
 import com.google.cloud.spring.data.firestore.Document;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 
 @Document(collectionName = "JavaSighting")
 public class Sighting {
@@ -12,12 +17,21 @@ public class Sighting {
     private String id;
     private Station station;
     private Train train;
-    private String timestamp; //later this will be datetime object
 
-    public Sighting(Station station, Train train, String timestamp) {
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm")
+    private Date timestamp; //later this will be datetime object
+
+    public Sighting() {
+
+    }
+
+    public Sighting(Station station, Train train, LocalDateTime timestamp) {
         this.station = station;
         this.train = train;
-        this.timestamp = timestamp;
+        this.timestamp = java.util.Date
+                .from(timestamp.atZone(ZoneId.systemDefault())
+                        .toInstant());
+
     }
 
     public String getId() {
@@ -44,11 +58,11 @@ public class Sighting {
         this.train = train;
     }
 
-    public String getTimestamp() {
+    public Date getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(String timestamp) {
+    public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
     }
 }

--- a/src/main/java/com/example/trainspottingjava/sighting/service/SightingService.java
+++ b/src/main/java/com/example/trainspottingjava/sighting/service/SightingService.java
@@ -14,7 +14,7 @@ public class SightingService {
 
     public void confirmTrainID(Sighting sighting, TrainRepository trainRepository){
 
-        String trainID = sighting.getTrain().getId();
+        String trainID = sighting.getTrain().getTrainId();
         int trainNum = sighting.getTrain().getTrainNumber();
         List<Train> trains = trainRepository.findAllByOrderByName().buffer().blockFirst();
 
@@ -29,10 +29,10 @@ public class SightingService {
             //then set the ID   (for now I'm assuming the other data is correct, but some validation here would be good)
 
             if (matchingTrain == null) { // If the train does not exist, add it.
-                String newId = trainRepository.save(sighting.getTrain()).block().getId();
+                String newId = trainRepository.save(sighting.getTrain()).block().getTrainId();
                 sighting.getTrain().setId(newId);
             } else {
-                sighting.getTrain().setId(matchingTrain.getId());
+                sighting.getTrain().setId(matchingTrain.getTrainId());
             }
         } else { //if train does have id already
             //  TODO If I have time, we should check if that id exists in the db and if not reassign


### PR DESCRIPTION
Type of sighting time is now a timestamp on google cloud rather than string 

- this might break the trains/{id}/sighting GET endpoint, if so I'll make a new branch and fix that 